### PR TITLE
Enable custom container options

### DIFF
--- a/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
+++ b/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
@@ -131,6 +131,8 @@ server {
         fastcgi_param SCRIPT_NAME     $fastcgi_script_name;
         fastcgi_index index.php;
         include fastcgi_params;
+        fastcgi_param PHP_VALUE /etc/php.d/custom.ini;
+        fastcgi_param PHP_VALUE /etc/php.d/environment.ini;
     }
 
     # Cache static files


### PR DESCRIPTION
### Purpose

This patch permits the Elastic Beanstalk container options (set-able in the web console by clicking `Edit Configuration` and then the `Container` tab)
