### PR TITLE
Fix ssl wo varnish

### DIFF
--- a/build
+++ b/build
@@ -205,7 +205,7 @@ if [ $SSL ]; then
     /bin/sed -i "149i\ " /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
     /bin/sed -i "150i\          # copy nginx server.conf to ssl.conf and add the necessary lines to enable ssl" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
     /bin/sed -i "151i\          \`/usr/bin/sudo cp -f /etc/nginx/conf.d/server.conf /etc/nginx/conf.d/ssl.conf\`" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
-    /bin/sed -i "152i\          \`/usr/bin/sudo sed -i '28 d' /etc/nginx/conf.d/ssl.conf\`" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb # delete the listen 8080; command
+    /bin/sed -i "152i\          \`/usr/bin/sudo sed -i '/^\s*listen/ d' /etc/nginx/conf.d/ssl.conf\`" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb # delete the listen 8080; command if there
     /bin/sed -i "153i\          \`/usr/bin/sudo sed -i '28i\    listen 443 default_server ssl;' /etc/nginx/conf.d/ssl.conf\`" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
     /bin/sed -i "154i\          \`/usr/bin/sudo sed -i '29i\    ssl_certificate \/etc\/ssl\/certs\/server.crt;' /etc/nginx/conf.d/ssl.conf\`" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb
     /bin/sed -i "155i\          \`/usr/bin/sudo sed -i '30i\    ssl_certificate_key \/etc\/ssl\/certs\/server.key;' /etc/nginx/conf.d/ssl.conf\`" /tmp/build/opt/elasticbeanstalk/srv/hostmanager/lib/elasticbeanstalk/hostmanager/utils/nginxutil.rb


### PR DESCRIPTION
### Purpose

fixes an issue whereby if varnish is not installed then the root directive of the ssl.conf file is deleted
